### PR TITLE
feat: implement edge caching for API responses

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -62,9 +62,6 @@ export default defineNuxtConfig({
   },
 
   routeRules: {
-    '/api/releases/**': {
-      headers: { 'Cache-Control': 'public, max-age=3600', },
-    },
     '/repo/**': { swr: true },
     '/': { prerender: true },
   },

--- a/server/api/releases/[owner]/[repo].get.ts
+++ b/server/api/releases/[owner]/[repo].get.ts
@@ -1,40 +1,46 @@
 import { API_ERRORS } from '~~/server/constants/api-errors';
 import { GITHUB_STATUS } from '~~/server/constants/gh-status';
+import { withEdgeCache } from '~~/server/utils/cacheHandler';
 import { fetchGitHubReleases, validatePaginationParams } from '~~/server/utils/gh-releases';
 
-export default defineEventHandler(async (event): Promise<ReleasesResponse> => {
-  const { owner, repo } = getRouterParams(event);
-  const query = getQuery(event);
+export default defineEventHandler(async (event) => {
+  return withEdgeCache<ReleasesResponse>(event, async () => {
+    const { owner, repo } = getRouterParams(event);
+    const query = getQuery(event);
 
-  if (!owner || !repo) {
-    throw createError(API_ERRORS.MISSING_PARAMS);
-  }
-
-  if (!/^[\w.-]+$/.test(owner) || !/^[\w.-]+$/.test(repo)) {
-    throw createError(API_ERRORS.INVALID_FORMAT);
-  }
-
-  try {
-    const { page, perPage } = validatePaginationParams(query);
-
-    return await fetchGitHubReleases(owner, repo, page, perPage);
-  } catch (error: unknown) {
-    console.error('GitHub API error:', error);
-
-    if (isOctokitError(error)) {
-      if (error.status === GITHUB_STATUS.NOT_FOUND) {
-        throw createError(API_ERRORS.REPOSITORY_NOT_FOUND);
-      }
-
-      if (error.status === GITHUB_STATUS.FORBIDDEN) {
-        throw createError(API_ERRORS.RATE_LIMIT_EXCEEDED);
-      }
-
-      if (error.status >= GITHUB_STATUS.SERVER_ERROR_MIN) {
-        throw createError(API_ERRORS.GITHUB_SERVER_ERROR);
-      }
+    if (!owner || !repo) {
+      throw createError(API_ERRORS.MISSING_PARAMS);
     }
 
-    throw createError(API_ERRORS.INTERNAL_ERROR);
-  }
+    if (!/^[\w.-]+$/.test(owner) || !/^[\w.-]+$/.test(repo)) {
+      throw createError(API_ERRORS.INVALID_FORMAT);
+    }
+
+    try {
+      const { page, perPage } = validatePaginationParams(query);
+
+      return await fetchGitHubReleases(owner, repo, page, perPage);
+    } catch (error: unknown) {
+      console.error('GitHub API error:', error);
+
+      if (isOctokitError(error)) {
+        if (error.status === GITHUB_STATUS.NOT_FOUND) {
+          throw createError(API_ERRORS.REPOSITORY_NOT_FOUND);
+        }
+
+        if (error.status === GITHUB_STATUS.FORBIDDEN) {
+          throw createError(API_ERRORS.RATE_LIMIT_EXCEEDED);
+        }
+
+        if (error.status >= GITHUB_STATUS.SERVER_ERROR_MIN) {
+          throw createError(API_ERRORS.GITHUB_SERVER_ERROR);
+        }
+      }
+
+      throw createError(API_ERRORS.INTERNAL_ERROR);
+    }
+  }, {
+    maxAge: 600,
+    sMaxAge: 14400
+  });
 });

--- a/server/utils/cacheHandler.ts
+++ b/server/utils/cacheHandler.ts
@@ -1,0 +1,64 @@
+import type { H3Event } from 'h3';
+import { cacheApi, createCacheKey } from './edgeCache';
+
+/**
+ * Options for the Edge Cache handler.
+ */
+export interface EdgeCacheOptions {
+  /**
+   * max-age for the cache in seconds.
+   *
+   * @default 300
+   */
+  maxAge?: number;
+  /**
+   * s-maxage for shared caches in seconds.
+   *
+   * @default 3600
+   */
+  sMaxAge?: number;
+  /**
+   * Additional headers to set on the cached response.
+   */
+  headers?: Record<string, string>;
+}
+
+/**
+ * A higher-order function that handles caching for Cloudflare Workers.
+ *
+ * It checks the cache first, and if a cached response is found,
+ * it returns that. If not, it calls the handler function, caches the response,
+ * and returns the data.
+ */
+export async function withEdgeCache<T>(
+  event: H3Event,
+  handler: (event: H3Event) => Promise<T>,
+  options: EdgeCacheOptions = {}
+): Promise<T | Response> {
+  if (!cacheApi) {
+    return await handler(event);
+  }
+
+  const {
+    maxAge = 300,
+    sMaxAge = 3600,
+    headers = { 'Content-Type': 'application/json' }
+  } = options;
+  const cacheKey = createCacheKey(event);
+
+  const cached = await cacheApi.match(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  const result = await handler(event);
+  const response = new Response(JSON.stringify(result));
+  response.headers.set('Cache-Control', `public, max-age=${maxAge}, s-maxage=${sMaxAge}`);
+  for (const [key, value] of Object.entries(headers)) {
+    response.headers.set(key, value);
+  }
+
+  event.waitUntil(cacheApi.put(cacheKey, response.clone()));
+
+  return { ...result, cacheHit: false };
+}

--- a/server/utils/cacheHandler.ts
+++ b/server/utils/cacheHandler.ts
@@ -60,5 +60,5 @@ export async function withEdgeCache<T>(
 
   event.waitUntil(cacheApi.put(cacheKey, response.clone()));
 
-  return { ...result, cacheHit: false };
+  return result;
 }

--- a/server/utils/edgeCache.ts
+++ b/server/utils/edgeCache.ts
@@ -1,0 +1,11 @@
+import type { H3Event } from 'h3';
+
+export const cacheApi: Cache | undefined =
+  typeof caches !== 'undefined' && 'default' in caches
+    ? (caches.default as Cache)
+    : undefined;
+
+export function createCacheKey(event: H3Event): Request {
+  const reqUrl = getRequestURL(event);
+  return new Request(reqUrl.toString(), event);
+}


### PR DESCRIPTION
This pull request introduces a caching mechanism for API responses using an edge cache, improving performance and reducing load on the server. The most significant changes include the addition of the `withEdgeCache` utility, integration of this caching mechanism into the releases API, and removal of redundant cache headers from the configuration.

### Caching Mechanism Implementation:

* [`server/utils/cacheHandler.ts`](diffhunk://#diff-c0fda9ff9b28367b633ff192a37e5dd80826eca056ad249dd4c16d9256d0a65fR1-R64): Added a `withEdgeCache` function to handle caching for Cloudflare Workers. This function checks for cached responses, caches new responses with configurable headers, and supports `max-age` and `s-maxage` options.

* [`server/utils/edgeCache.ts`](diffhunk://#diff-3068aa6aee397b02a34306521382d4a2ed7da6ff5030b7a3b48a3e3a50b4f67cR1-R11): Introduced the `cacheApi` object for accessing the default cache and a `createCacheKey` function to generate unique cache keys based on the request.

### Integration with Releases API:

* `server/api/releases/[owner]/[repo].get.ts`: Integrated the `withEdgeCache` utility into the releases API handler, enabling caching with a `max-age` of 600 seconds and an `s-maxage` of 14400 seconds. ([server/api/releases/[owner]/[repo].get.tsR3-R7](diffhunk://#diff-52d7af67e0aa87884a9a231b32ea89c80455272e7e78a2703c1e59d6cf5dbd73R3-R7), [server/api/releases/[owner]/[repo].get.tsR42-R45](diffhunk://#diff-52d7af67e0aa87884a9a231b32ea89c80455272e7e78a2703c1e59d6cf5dbd73R42-R45))

### Configuration Updates:

* [`nuxt.config.ts`](diffhunk://#diff-5977891bf10802cdd3cde62f0355105a1662e65b02ae4fb404a27bb0f5f53a07L65-L67): Removed hardcoded cache-control headers for the `/api/releases/**` route, as caching is now handled dynamically within the API logic.