### PR TITLE
Fix arrow key navigation by adding activeRelease computed property

### DIFF
--- a/app/components/release/ReleaseList.vue
+++ b/app/components/release/ReleaseList.vue
@@ -11,6 +11,12 @@ const emit = defineEmits<{
 const el = useTemplateRef('el');
 const { releases, loading, error, pagination, reset, loadMore } = useGitHubReleases();
 
+const activeRelease = computed(() =>
+  props.activeTag
+    ? releases.value.find((r) => r.tag === props.activeTag)
+    : null
+);
+
 // Watch repository changes and load releases
 watch(() => props.repository, (newRepo) => {
   if (newRepo) {


### PR DESCRIPTION
Fixes a bug where arrow up/down keyboard shortcuts were not working when navigating between releases.

Added an `activeRelease` computed property that derives the currently active release from the `activeTag` prop by finding the matching release in the releases array.